### PR TITLE
Changed slf4j-simple to runtime dependency

### DIFF
--- a/addons/fabric8-camel-maven-plugin/pom.xml
+++ b/addons/fabric8-camel-maven-plugin/pom.xml
@@ -102,6 +102,7 @@
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-simple</artifactId>
       <version>1.7.12</version>
+      <scope>runtime</scope>
     </dependency>
 
   </dependencies>


### PR DESCRIPTION
SLF4j runtime bindings like slf4j-simple should only be a test or runtime scope dependency, otherwise you'll see runtime SLF4J runtime binding errors if a different project is using, for example slf4j-log4j runtime binding.

It doesn't appear that this plugin is using any SLF4j apis directly, so possible that slf4j-simple dependency could just be removed all together...
