### PR TITLE
Revert "Upgrade Gitective to version 0.9.15"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,7 @@
     <furnace.version>2.23.5.Final</furnace.version>
     <jboss.forge.version>3.2.2.Final</jboss.forge.version>
     <jboss.roaster.version>2.18.7.Final</jboss.roaster.version>
-    <gitective.version>0.9.15</gitective.version>
+    <gitective.version>0.9.14</gitective.version>
 
     <!-- NOTE these properties are used to generate the addons/utils/src/main/resources/io/fabric8/forge/addon/utils/versions.properties file -->
     <arquillian.version>1.1.11.Final</arquillian.version>


### PR DESCRIPTION
This reverts commit 1d784317d4fa2203512e1af437b2444cd506e2d2.

There is a little bug in the JGit version used by gitective.
