### PR TITLE
add ability to switch to cxf-snapshots

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -282,6 +282,68 @@
 
   <profiles>
     <profile>
+      <id>cxf-snapshot</id>
+      <properties>
+        <cxf.version>3.2.0-SNAPSHOT</cxf.version>
+      </properties>
+      <repositories>
+        <repository>
+          <id>apache-snapshots</id>
+          <url>https://repository.apache.org/content/groups/snapshots</url>
+          <name>ASF Snapshots</name>
+          <releases>
+            <enabled>false</enabled>
+          </releases>
+          <snapshots>
+            <enabled>true</enabled>
+          </snapshots>
+        </repository>
+      </repositories>
+      <pluginRepositories>
+        <pluginRepository>
+          <id>apache-snapshots</id>
+          <url>https://repository.apache.org/content/groups/snapshots</url>
+          <name>ASF Snapshots</name>
+          <releases>
+            <enabled>false</enabled>
+          </releases>
+          <snapshots>
+            <enabled>true</enabled>
+          </snapshots>
+        </pluginRepository>
+      </pluginRepositories>
+      <dependencyManagement>
+        <dependencies>
+          <dependency>
+            <groupId>org.apache.cxf</groupId>
+            <artifactId>cxf-rt-rs-service-description</artifactId>
+            <version>${cxf.version}</version>
+          </dependency>
+          <dependency>
+            <groupId>org.apache.cxf</groupId>
+            <artifactId>cxf-integration-cdi</artifactId>
+            <version>${cxf.version}</version>
+          </dependency>
+          <dependency>
+            <groupId>org.apache.cxf</groupId>
+            <artifactId>cxf-rt-frontend-jaxrs</artifactId>
+            <version>${cxf.version}</version>
+          </dependency>
+          <dependency>
+            <groupId>org.apache.cxf</groupId>
+            <artifactId>cxf-rt-transports-http</artifactId>
+            <version>${cxf.version}</version>
+          </dependency>
+          <dependency>
+            <groupId>org.apache.cxf</groupId>
+            <artifactId>cxf-rt-management</artifactId>
+            <version>${cxf.version}</version>
+          </dependency>
+        </dependencies>
+      </dependencyManagement>
+
+    </profile>
+    <profile>
       <id>fabric8-snapshot</id>
       <properties>
         <fabric8.version>2.3-SNAPSHOT</fabric8.version>


### PR DESCRIPTION
i've been wanting to get rid of this silly message:

```
Both io.fabric8.forge.rest.RootResource#index and io.fabric8.forge.rest.RootResource#index are equal candidates for handling the current request which can lead to unpredictable results
```

which has been resolved in cxf 3.2.0 which is unreleased at the moment:

https://issues.apache.org/jira/browse/CXF-6896